### PR TITLE
[CURA-11035] Plugins specify a version-range, slots just a version.

### DIFF
--- a/cura/plugins/slots/handshake/v0/handshake.proto
+++ b/cura/plugins/slots/handshake/v0/handshake.proto
@@ -10,13 +10,13 @@ service HandshakeService {
 
 message CallRequest {
    cura.plugins.v0.SlotID slot_id = 1;
-   string version_range = 2;
+   string version = 2;
    string plugin_name = 3;
    string plugin_version = 4;
 }
 
 message CallResponse {
-   string slot_version = 1;
+   string slot_version_range = 1;
    string plugin_name = 2;
    string plugin_version = 3;
    repeated cura.plugins.v0.SlotID broadcast_subscriptions = 4;

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class CustomBuildCommand(build_py):
 
 setup(
     name = "CuraEngineGRPC",
-    version = "0.1.1",
+    version = "0.1.2",
     description = "A gRPC package using proto files with type hints",
     author = "UltiMaker",
     author_email = "cura@ultimaker.com",

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class CustomBuildCommand(build_py):
 
 setup(
     name = "CuraEngineGRPC",
-    version = "0.1.2",
+    version = "0.1.1",
     description = "A gRPC package using proto files with type hints",
     author = "UltiMaker",
     author_email = "cura@ultimaker.com",


### PR DESCRIPTION
Not the other way around as we have now. This also adheres closer to the way we handle front-end plugins. Ideally you'd maybe want both of them to be ranges, but that's for the future.
