### PR TITLE
CURA-11796 Combine the long and short unretracts at nozzle switch

### DIFF
--- a/cura/plugins/v0/gcodepath.proto
+++ b/cura/plugins/v0/gcodepath.proto
@@ -41,4 +41,5 @@ message GCodePath {
   double flow_ratio = 20;
   bool is_bridge_path = 21;
   int64 z_offset = 22;
+  bool retract_for_nozzle_switch = 23;
 }


### PR DESCRIPTION
Add a new parameter of GCodePath to be passed to plugins.

Contributes to CURA-11796

Comes with 