### PR TITLE
Increment minor version after last changes

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,1 +1,1 @@
-version: 0.2.0-alpha.0
+version: 0.2.1


### PR DESCRIPTION
As we have recently made some changes on the communication protocol, the minor version should have been incremented.
I also removed the "alpha" tag because this has been released (and it is still a 0-major version)