### PR TITLE
Add Z coordinate for GCodePath points

### DIFF
--- a/cura/plugins/slots/comb/v0/comb.proto
+++ b/cura/plugins/slots/comb/v0/comb.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package cura.plugins.slots.comb.v0;
 
-import "cura/plugins/v0/polygons.proto";
 import "cura/plugins/v0/toolpaths.proto";
+import "cura/plugins/v0/point2d.proto";
 
 service CombModifyService {
   rpc Call(CallRequest) returns (CallResponse) {}

--- a/cura/plugins/v0/mesh.proto
+++ b/cura/plugins/v0/mesh.proto
@@ -2,11 +2,7 @@ syntax = "proto3";
 
 package cura.plugins.v0;
 
-message Point3D {
-  float x = 1;
-  float y = 2;
-  float z = 3;
-}
+import "cura/plugins/v0/point3d.proto";
 
 message Triangle {
   Point3D p1 = 1;

--- a/cura/plugins/v0/point2d.proto
+++ b/cura/plugins/v0/point2d.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package cura.plugins.v0;
+
+message Point2D {
+  float x = 1;
+  float y = 2;
+}

--- a/cura/plugins/v0/point3d.proto
+++ b/cura/plugins/v0/point3d.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package cura.plugins.v0;
+
+message Point3D {
+  float x = 1;
+  float y = 2;
+  float z = 3;
+}

--- a/cura/plugins/v0/polygons.proto
+++ b/cura/plugins/v0/polygons.proto
@@ -2,13 +2,10 @@ syntax = "proto3";
 
 package cura.plugins.v0;
 
-message Point2D {
-  sint64 x = 1;
-  sint64 y = 2;
-}
+import "cura/plugins/v0/point3d.proto";
 
 message OpenPath {
-  repeated Point2D path = 1;
+  repeated Point3D path = 1;
 }
 
 message OpenPaths {
@@ -16,11 +13,11 @@ message OpenPaths {
 }
 
 message ClosedPath {
-  repeated Point2D path = 1;
+  repeated Point3D path = 1;
 }
 
 message FilledPath {
-  repeated Point2D path = 1;
+  repeated Point3D path = 1;
 }
 
 message Polygon {

--- a/cura/plugins/v0/toolpaths.proto
+++ b/cura/plugins/v0/toolpaths.proto
@@ -2,14 +2,14 @@ syntax = "proto3";
 
 package cura.plugins.v0;
 
-import "cura/plugins/v0/polygons.proto";
+import "cura/plugins/v0/point3d.proto";
 
 message TravelPath {
-  repeated Point2D points = 1;
+  repeated Point3D points = 1;
 }
 
 message ExtrusionJunction {
-  Point2D point = 1;
+  Point3D point = 1;
   uint32 width = 2;
 }
 


### PR DESCRIPTION
GCodePath now contain a Z coordinate because each individual point may have a vertical offset

CURA-12080
CURA-12081