### PR TITLE
CURA-12259 Bump version for 5.9

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,1 +1,1 @@
-version: 0.2.1
+version: 0.3.0


### PR DESCRIPTION
CURA-12259

We made some significant changes between 5.8 and 5.9, so now is the time to bump the version number in order to indicate this.